### PR TITLE
Fix warnings and remove unused

### DIFF
--- a/src/Backends/LocationBackend.vala
+++ b/src/Backends/LocationBackend.vala
@@ -51,7 +51,7 @@ public class Privacy.Backends.Location : Privacy.AbstractBackend {
                     app_list_widget.add_app (app_info);
                 }
             }
-        } catch (IOError e) {
+        } catch (Error e) {
             warning ("Error getting list of clients connected to geoclue: %s", e.message);
         }
     }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -18,8 +18,6 @@
  */
 
 public class Privacy.Indicator : Wingpanel.Indicator {
-    private const string ICON_NAME = "find-location-symbolic";
-
     private Widgets.DisplayWidget? indicator_icon = null;
     private Gtk.ModelButton settings;
 
@@ -69,24 +67,20 @@ public class Privacy.Indicator : Wingpanel.Indicator {
             }
             main_grid.add (settings);
 
-            connections ();
+            settings.clicked.connect (() => {
+                close ();
+                show_settings ();
+            });
         }
 
         return main_grid;
     }
 
-    public void connections () {
-        settings.clicked.connect (() => {
-            close ();
-            show_settings ();
-        });
-    }
-
     private void show_settings () {
         try {
-            Gtk.show_uri (null, "settings://security/privacy", Gdk.CURRENT_TIME);
+            AppInfo.launch_default_for_uri ("settings://security/privacy", null);
         } catch (Error e) {
-            warning ("%s\n", e.message);
+            warning ("%s", e.message);
         }
     }
 

--- a/src/Services/DbusInterfaces.vala
+++ b/src/Services/DbusInterfaces.vala
@@ -21,6 +21,6 @@ namespace Privacy.Services.DBusInterfaces {
     [DBus (name = "org.freedesktop.GeoClue2.Manager")]
     interface GeoclueManager : DBusProxy {
         public abstract bool InUse { get; }
-        public abstract string[] GetClientList () throws IOError; // vala-lint=naming-convention
+        public abstract string[] GetClientList () throws Error; // vala-lint=naming-convention
     }
 }

--- a/src/Widgets/AppList.vala
+++ b/src/Widgets/AppList.vala
@@ -56,7 +56,11 @@ public class Privacy.Widgets.AppList : Gtk.Revealer {
             main_grid.add (app);
         }
 
-        main_grid.add (new Wingpanel.Widgets.Separator ());
+        var separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL) {
+            margin_top = 3,
+            margin_bottom = 3
+        };
+        main_grid.add (separator);
         main_grid.show_all ();
         if (app_list.size > 0) {
             set_reveal_child (true);


### PR DESCRIPTION
Fix the following error messages:

```
../src/Services/DbusInterfaces.vala:24.9-24.46: warning: DBus methods are recommended to throw at least `GLib.Error' or `GLib.DBusError, GLib.IOError'
        public abstract string[] GetClientList () throws IOError; // vala-lint=naming-convention
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../src/Widgets/AppList.vala:59.28-59.54: warning: `Wingpanel.Widgets.Separator' has been deprecated since 3.0.0. Use Gtk.Separator
../src/Indicator.vala:87.13-87.24: warning: `Gtk.show_uri' has been deprecated since 3.22
```

Also remove unused constant `ICON_NAME` in Indicator.vala
